### PR TITLE
Fixed wrong user name variable in server_set_jar()

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1016,7 +1016,7 @@ server_set_jar() {
 		fi
 		
 		if [[ ! -z "$jar" ]]; then
-			as_user "${SERVER_USER[$1]}" "ln -sf \"$jar\" \"${SERVER_JAR[$1]}\""
+			as_user "${SERVER_USER_NAME[$1]}" "ln -sf \"$jar\" \"${SERVER_JAR[$1]}\""
 			echo "Server \"${SERVER_NAME[$1]}\" is now using \"$jar\"."
 		fi
 	else


### PR DESCRIPTION
Fixes the issue described in https://github.com/marcuswhybrow/minecraft-server-manager/issues/39
