### PR TITLE
Modify/Add server.properties

### DIFF
--- a/bash_completion/msm
+++ b/bash_completion/msm
@@ -118,7 +118,7 @@ _msm() {
 					__init_server "${COMP_WORDS[1]}"
 					
 					if [[ $COMP_CWORD == 2 ]]; then
-						options="start stop restart status connected worlds logroll backup jar whitelist blacklist operator gamemode kick say time toggledownfall give xp save cmd cmdlog console"
+						options="start stop restart status connected worlds logroll backup jar whitelist blacklist operator gamemode kick say time toggledownfall give xp save cmd cmdlog console config"
 					else
 						case "${COMP_WORDS[2]}" in
 							stop|restart)
@@ -247,6 +247,11 @@ _msm() {
 									options="on off all"
 								fi
 								;;
+							config)
+							        if [[ $COMP_CWORD == 3 ]]; then
+							                options="$(more $SERVER_CONF | sed 's/=.*$//' | grep -v '#')";
+							        fi
+							        ;;
 						esac
 								
 					fi

--- a/init/msm
+++ b/init/msm
@@ -25,7 +25,7 @@ CONF="${MSM_CONF:-/etc/msm.conf}"
 
 
 ### The Minecraft Server Manager version, use "msm version" to check yours.
-VERSION="0.4.0"
+VERSION="0.4.w0"
 
 
 ### Config variables the user should not need/want to change
@@ -1980,6 +1980,26 @@ command_server_console() {
 	fi
 }
 
+# Sets a parameter in the config file if it exists otherwise inserts the
+# paramerter.
+# if the server is running it will do a restart to ensure the parameter is 
+# loaded
+# $1: The server ID
+# $2: The parameter
+# $3: The value to set it to
+command_set_config() {
+        if [[ -f "${SERVER_CONF[$1]}" ]]; then
+                if grep "$2" ${SERVER_CONF[$1]} >/dev/null; then
+                        sed -i /$2=/s/.*/"$2=$3"/g ${SERVER_CONF[$1]}
+                else
+                        echo "$2=$3" >> ${SERVER_CONF[$1]}
+                fi
+        fi
+        if server_is_running "$1"; then
+                echo "Server is running, restarting in 10secs to ensure update"
+                command_server_restart $1;
+        fi
+}
 
 ### Main Functions
 
@@ -2742,7 +2762,7 @@ main() {
 	register_command "<name:server> cmd <strings>" "command_server_cmd"
 	register_command "<name:server> cmdlog <strings>" "command_server_cmdlog"
 	register_command "<name:server> console" "command_server_console"
-	
+	register_command "<name:server> config <string> <string>" "command_set_config"	
 	# This function call matches the user input to a registered command
 	# signature, and then calls that commands handler function with positional
 	# arguments containing any variable strings.

--- a/msm.conf
+++ b/msm.conf
@@ -21,6 +21,7 @@ USERNAME="minecraft"
 
 # Where new servers are stored
 SERVER_STORAGE_PATH="/opt/msm/servers"
+DEFAULT_SERVER_CONF="server.properties"
 
 # Where runnable jar files for use by servers are stored
 JAR_STORAGE_PATH="/opt/msm/jars"
@@ -219,3 +220,4 @@ DEFAULT_CONFIRM_XP_FAIL_NO_USER="Can't find user .+"
 
 # The message logged when the experience amount given is an invalid format
 DEFAULT_CONFIRM_XP_FAIL_INVALID_AMOUNT="Invalid exp count: .+"
+


### PR DESCRIPTION
Added ability to modify server properties using "msm $servername config property value". Also added tab completion for said command.
Added 'DEFAULT_SERVER_CONF="server.properties"' to the msm conf, unsure if correct or not, but necessary for tab completion.
