### PR TITLE
Small patch for matching updated messages in msm.conf

### DIFF
--- a/msm.conf
+++ b/msm.conf
@@ -192,7 +192,7 @@ DEFAULT_CONFIRM_TIME_ADD="CONSOLE: Added .+ to time|Added .+ to the time"
 DEFAULT_CONFIRM_TIME_ADD_FAIL="Unable to convert time value|.+ is not a valid number"
 
 # The start of the message logged when downfall is toggled
-DEFAULT_CONFIRM_TOGGLEDOWNFALL="CONSOLE: Toggling downfall on\|off for world|Toggled downfall"
+DEFAULT_CONFIRM_TOGGLEDOWNFALL="CONSOLE: Toggling downfall (on|off) for world|Toggled downfall"
 
 # The start of the message logged when the togglefownfall command is given a
 # world name that does not exist


### PR DESCRIPTION
Since you're matching the messages using regular expressions, I took the liberty in adding the new messages as alternatives. Also, the toggle downfall had a bug where the pipe character wasn't escaped which would cause the string never to be matched.
