### PR TITLE
Added Upstart support to installer and init script.

### DIFF
--- a/installers/ubuntu.sh
+++ b/installers/ubuntu.sh
@@ -1,0 +1,29 @@
+wget -q https://raw.github.com/marcuswhybrow/minecraft-server-manager/master/installers/common.sh -O /tmp/msmcommon.sh
+source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
+
+function update_system_packages() {
+    install_log "Updating sources"
+    sudo apt-get update || install_error "Couldn't update package list"
+    sudo apt-get upgrade || install_error "Couldn't upgrade packages"
+}
+
+function install_dependencies() {
+    install_log "Installing required packages"
+    sudo apt-get install screen rsync zip || install_error "Couldn't install dependencies"
+}
+
+function reload_cron() {
+    install_log "Reloading cron service"
+    sudo service cron reload
+}
+
+function enable_init() {
+    install_log "Downloading latest upstart config"
+    sudo wget https://raw.github.com/marcuswhybrow/minecraft-server-manager/latest/upstart/msm.conf \
+        -O "$dl_dir/msm.conf.upstart" || install_error "Couldn't download upstart config file"
+    install_log "Enabling automatic startup and shutdown"
+    sudo install -b -m0644  "$dl_dir/msm.conf.upstart" /etc/init/msm.conf
+    install_log "MSM can now be globally started and stopped via 'start msm' and 'stop msm'."
+}
+
+install_msm

--- a/upstart/msm.conf
+++ b/upstart/msm.conf
@@ -1,0 +1,2 @@
+# vim:syn=upstart:
+

--- a/upstart/msm.conf
+++ b/upstart/msm.conf
@@ -1,2 +1,17 @@
-# vim:syn=upstart:
+# Minecraft Server Manager upstart service
 
+description     "Minecraft Server Manager"
+author          "Matt Sicker <boards@gmail.com>"
+
+start on started network-services
+stop on stopping network-services
+
+pre-stop script
+    source /etc/init.d/msm
+    command_stop_now
+end script
+
+script
+    source /etc/init.d/msm
+    command_start
+end script


### PR DESCRIPTION
Thankfully, Upstart support wasn't too difficult to add considering it works well with SysV init scripts. I have not tested this, but it should work in theory.

Two new files have been added: an upstart `/etc/init/msm.conf` file, and a new installer for Ubuntu/Upstart.
