### PR TITLE
BungeeCord

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1400,7 +1400,7 @@ server_stop_now() {
 		
 		echo -n "Stopping the server... "
 		
-		server_eval "$1" "stop"
+		server_eval "$1" STOP
 		STOP_COUNTDOWN[$1]="false"
 		RESTART_COUNTDOWN[$1]="false"
 		server_wait_for_stop "$1"
@@ -1850,7 +1850,7 @@ manager_stop_all_servers() {
 				if server_is_running "$server"; then
 					stop_tick="$(( ${max_countdown} - ${SERVER_STOP_DELAY[$server]} ))"
 					if [[ "$stop_tick" == "$tick" ]]; then
-						server_eval "$server" "stop"
+						server_eval "$server" STOP
 						STOP_COUNTDOWN[$server]="false"
 					fi
 				fi
@@ -1893,7 +1893,7 @@ manager_stop_all_servers_now() {
 			was_running[$server]="true"
 			any_running="true"
 			echo "Server \"${SERVER_NAME[$server]}\" was running, now stopping."
-			server_eval "$server" "stop"
+			server_eval "$server" STOP
 		else
 			echo "Server \"${SERVER_NAME[$server]}\" was NOT running."
 			was_running[$server]="false"
@@ -1984,7 +1984,7 @@ command_start() {
 
 # Stops all servers after a delay
 command_stop() {
-	manager_stop_all_servers "stop"
+	manager_stop_all_servers STOP
 }
 
 # Stops all servers without delay

--- a/versioning/bungeecord/1.0.sh
+++ b/versioning/bungeecord/1.0.sh
@@ -1,0 +1,10 @@
+# MSM version file for BungeeCord 1.0 and above
+
+console_command STOP "end" \
+  "Proxy Stopped."
+
+console_command CONNECTED "glist" \
+  "([^\ ]*)?(, [^\ ]+)*$" \
+  "$"
+
+console_command SAY "alert <message>"

--- a/versioning/minecraft/1.2.0.sh
+++ b/versioning/minecraft/1.2.0.sh
@@ -2,6 +2,8 @@
 
 console_event START:30 "Done"
 
+console_command STOP "stop"
+
 console_command WHITELIST_ON "whitelist on"
 console_command WHITELIST_OFF "whitelist off"
 console_command WHITELIST_ADD "whitelist add <player>"

--- a/versioning/versions.txt
+++ b/versioning/versions.txt
@@ -9,3 +9,6 @@ minecraft/1.3.0
 # CraftBukkit versions
 craftbukkit/1.2.0
 craftbukkit/1.3.0
+
+# BungeeCord versions
+bungeecord/1.0


### PR DESCRIPTION
With the release of BungeeCord, MSM because uncompatible. MSM is
uncompatible because of the "stop" command being hardcoded into MSM.
BungeeCord uses 'end' instead of 'stop', this fixes that.

/\* WARNING */ NOT TESTED, BUT WORKS IN THERY
