### PR TITLE
Add default minecraft jargroup on install

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -144,6 +144,12 @@ function update_msm() {
     sudo /etc/init.d/msm update --noinput
 }
 
+# Updates rest of MSM using init script updater
+function setup_jargroup() {
+    install_log "Setup default jar groups"
+    sudo /etc/init.d/msm jargroup create minecraft https://s3.amazonaws.com/MinecraftDownload/launcher/minecraft_server.jar
+}
+
 function install_complete() {
     install_log "Done. Type 'msm help' to get started. Have fun!"
 }
@@ -162,5 +168,6 @@ function install_msm() {
     install_init
     enable_init
     update_msm
+    setup_jargroup
     install_complete
 }


### PR DESCRIPTION
This make msm much easier out of the box, as it's basically required to create servers. Having it by default makes msm cleaner. I'd also like to add a lot of other default jargroups, but this is a start.
