### PR TITLE
get rid of the message "No directory, logging in with HOME=/"

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -54,7 +54,8 @@ function install_dependencies() {
 # Verifies existence of or adds user for Minecraft server (default "minecraft")
 function add_minecraft_user() {
     install_log "Creating default user '${msm_user}'"
-    sudo useradd ${msm_user}
+    sudo useradd ${msm_user} \
+        --home /opt/msm
 }
 
 # Verifies existence and permissions of msm server directory (default /opt/msm)


### PR DESCRIPTION
While performing operations with the user mineraft a message appears that the home directory is not available.
