### PR TITLE
Add check for snapshot, check for release instead of minecraft

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1073,14 +1073,15 @@ jargroup_getlatest() {
                                     wget_opts=""
                                 fi
 
-                # If target contains the word 'minecraft' check JSON version file for correct filename
+                # If target contains the word 'release' or 'snapshot' check JSON version file for correct filename 
+                # Look for Latest tag to find the latest snapshot and release. Not sure what happens in the JSON after a snapshot is released though...
                 local target="$(as_user "$SETTINGS_USERNAME" "cat $SETTINGS_JAR_STORAGE_PATH/$1/$SETTINGS_JARGROUP_TARGET")"
-                if [[ "$target" == "minecraft" ]]; then
+                if [[ "$target" == "release" ]] || [[ "$target" == "snapshot" ]]; then
                     printf "Checking minecraft version JSON... "
                     local versions_url="http://s3.amazonaws.com/Minecraft.Download/versions/versions.json"
                     local versions_file="/tmp/minecraft_versions.json"
                     as_user "$SETTINGS_USERNAME" "wget --quiet $wget_opts --no-check-certificate -O '$versions_file' '$versions_url'"
-                    local latest_version=$(as_user "$SETTINGS_USERNAME" "cat '$versions_file' | egrep '^[[:space:]]*\"release\"' | cut -d':' -f2 | egrep -o '[[:digit:].]*'")
+                    local latest_version=$(as_user "$SETTINGS_USERNAME" "sed -n '/"latest"/,/}/p' $versions_file | grep $target | egrep -o '([0-9]+\.?)+|([0-9]+[a-zA-Z])+'")
                     if [[ -n "$latest_version" ]]; then
                         local jar_url="https://s3.amazonaws.com/Minecraft.Download/versions/$latest_version/minecraft_server.$latest_version.jar"
 


### PR DESCRIPTION
This is a tweak to #169

Instead of checking for 'minecraft'  it now checks for 'release' or 'snapshot' and grabs the latest released version as specified in the json.