### PR TITLE
Fix for issue #222 1.7.2 logging path

### DIFF
--- a/msm.conf
+++ b/msm.conf
@@ -100,7 +100,7 @@ DEFAULT_COMPLETE_BACKUP_FOLLOW_SYMLINKS="false"
 
 # The location of standard Minecraft server files, relative to the
 # server directory
-DEFAULT_LOG_PATH="server.log"
+DEFAULT_LOG_PATH="logs/latest.log"
 DEFAULT_PROPERTIES_PATH="server.properties"
 DEFAULT_WHITELIST_PATH="white-list.txt"
 DEFAULT_BANNED_PLAYERS_PATH="banned-players.txt"


### PR DESCRIPTION
Minecraft now logs to a different path, with the old path this would create a lot of tail processes.
