### PR TITLE
Added cron reload after MSM cron file installation

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -126,6 +126,7 @@ function install_config() {
 function install_cron() {
     install_log "Installing MSM cron file"
     sudo install -m0644 "$dl_dir/msm.cron" /etc/cron.d/msm || install_error "Couldn't install cron file"
+    sudo /etc/init.d/cron reload
 }
 
 # Installs init script into /etc/init.d


### PR DESCRIPTION
In the automatic installer the cron reload was missing. You would have to do this manually to enable periodic "save to disk" or world backups. I added the missing command after the MSM cron file is installed.
