### PR TITLE
Update common.sh installer for readability

### DIFF
--- a/installers/common.sh
+++ b/installers/common.sh
@@ -1,6 +1,6 @@
 msm_dir="/opt/msm"
 msm_user="minecraft"
-msm_user_system=false
+msm_user_system=true
 dl_dir="$(mktemp -d -t msm-XXX)"
 
 # Outputs an MSM INSTALL log line


### PR DESCRIPTION
Correcting semantic error in use of the msm_user_system value for code readability.  'false' should result in no system account and 'true' should result in a system account.
