### PR TITLE
Install required packages without prompting.

### DIFF
--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -5,12 +5,12 @@ source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 function update_system_packages() {
     install_log "Updating sources"
     sudo apt-get update || install_error "Couldn't update package list"
-    sudo apt-get upgrade || install_error "Couldn't upgrade packages"
+    sudo apt-get -y upgrade || install_error "Couldn't upgrade packages"
 }
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo apt-get install screen rsync zip || install_error "Couldn't install dependencies"
+    sudo apt-get -y install screen rsync zip || install_error "Couldn't install dependencies"
 }
 
 function enable_init() {


### PR DESCRIPTION
This eliminates the need for the user to choose Y during the upgrade and package installations.
