### PR TITLE
Fix #266. Set curl to follow redirects

### DIFF
--- a/installers/arch.sh
+++ b/installers/arch.sh
@@ -1,5 +1,5 @@
 UPDATE_URL="https://raw.github.com/marcuswhybrow/minecraft-server-manager/master"
-curl "${UPDATE_URL}/installers/common.sh" -o /tmp/msmcommon.sh  #wget isn't installed on Arch by default
+curl -L "${UPDATE_URL}/installers/common.sh" -o /tmp/msmcommon.sh  #wget isn't installed on Arch by default
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 
 function update_system_packages() {

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -16,7 +16,7 @@ function check_os() {
 function get_installer() {
     type curl 1>/dev/null 2>&1
     if [[ $? -eq 0 ]]; then
-        curl "${BASE_URL}/${INSTALL_SCRIPT}" -o /tmp/msminst.sh
+        curl -L "${BASE_URL}/${INSTALL_SCRIPT}" -o /tmp/msminst.sh
     else
         wget -q "${BASE_URL}/${INSTALL_SCRIPT}" -O /tmp/msminst.sh
     fi


### PR DESCRIPTION
raw.github.com has moved to ra.githubusercontent.com, but curl does not
follow redirects by default. Adding the -L flag to curl invocations
sets curl to follow redirects.
