### PR TITLE
Pr

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -2085,6 +2085,7 @@ command_start() {
 
 command_start_nodetach() {
       command_start
+      trap interrupt_wait TERM INT
       echo "You have specified nodetach : waiting for SIGINT or SIGTERM"
       while true; do sleep 1; done
 }


### PR DESCRIPTION
Hi,

I made a little change to have [docker](https://www.docker.com/) and/or supervisord support with msm.

Processus started by Docker must not return otherwise the container is stopped.

I added a "start nodetach" command to msm to prevent msm from detaching.
Then, msm will wait until a INT signal is received to properly close minecraft by calling command_stop.

Best Regards, 
