### PR TITLE
Update debian.sh

### DIFF
--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -19,7 +19,7 @@ function enable_init() {
     if [[ $? == 0 ]]; then
         sudo insserv msm
     else
-        sudo update-rc.d msm defaults
+        sudo update-rc.d msm defaults 99 10
     fi
 }
 


### PR DESCRIPTION
Update debian.sh script to eliminate "Cannot make directory '/var/run/screen': Permission denied" error on startup with Ubuntu 14.04 -- more information: https://bugs.launchpad.net/ubuntu/+source/screen/+bug/1380080