### PR TITLE
pre and post 1.7.0 log support

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -826,7 +826,7 @@ server_log_get_line() {
 			RETURN="${BASH_REMATCH[1]}"
 			return 0
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
 }
 
 # The same as server_log_get_line, but prints a dot instead of the log line
@@ -865,7 +865,7 @@ server_log_dots_for_lines() {
 				return 0
 			fi
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
 }
 
 # Sends as string to a server for execution
@@ -3150,7 +3150,7 @@ command_server_cmdlog() {
 		echo "Now watching logs (press Ctrl+C to exit):"
 		echo "..."
 		server_eval "$1" "${*:2}"
-		as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow --lines=5 --sleep-interval=0.1 ${SERVER_LOG_PATH[$1]}"
+		as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=5 --sleep-interval=0.1 ${SERVER_LOG_PATH[$1]}"
 	else
 		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi

--- a/init/msm
+++ b/init/msm
@@ -292,7 +292,7 @@ now() {
 # $1: A server log line
 # returns: Time in seconds since 1970-01-01 00:00:00 UTC
 log_line_get_time() {
-	time_string="$(echo "$1" | awk 'BEGIN{FS="[ \][/:]+"}; {print  $1 " " $2 ":" $3 ":" $4}')"
+	time_string="$(echo "$1" | awk -F'[] [/:]+' '{print  $1 " " $2 ":" $3 ":" $4}')"
 	date -d "$time_string" "+%s" 2> /dev/null
 }
 

--- a/init/msm
+++ b/init/msm
@@ -807,8 +807,6 @@ server_log_get_line() {
 	server_property "$1" CONSOLE_EVENT_REGEX
 
 	unset RETURN
-	# Make sure there is a server log to check
-	as_user "${SERVER_USERNAME[$1]}" "touch ${SERVER_LOG_PATH[$1]}"
 
 	local regex="${SERVER_CONSOLE_EVENT_OUTPUT_REGEX[$1]} ($3)"
 	local timeout_deadline=$(( $(now) + $4 ))
@@ -840,9 +838,6 @@ server_log_dots_for_lines() {
 	server_property "$1" USERNAME
 	server_property "$1" LOG_PATH
 	server_property "$1" CONSOLE_EVENT_REGEX
-
-	# Make sure there is a server log to check
-	as_user "${SERVER_USERNAME[$1]}" "touch ${SERVER_LOG_PATH[$1]}"
 
 	local regex="${SERVER_CONSOLE_EVENT_OUTPUT_REGEX[$1]} ($3)"
 	local timeout_deadline=$(( $(now) + $4 ))

--- a/init/msm
+++ b/init/msm
@@ -57,9 +57,6 @@ follow_links "$COMPLETION"; COMPLETION="$RETURN"
 
 ### Config variables the user should not need/want to change
 
-# The start of a regex to find a log line
-LOG_REGEX="^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.*\]"
-
 # Lazy allocation status
 ALLOCATED_SERVERS="false"
 ALLOCATED_WORLDS="false"
@@ -807,12 +804,13 @@ server_worlds_to_disk() {
 server_log_get_line() {
 	server_property "$1" USERNAME
 	server_property "$1" LOG_PATH
+	server_property "$1" CONSOLE_EVENT_REGEX
 
 	unset RETURN
 	# Make sure there is a server log to check
 	as_user "${SERVER_USERNAME[$1]}" "touch ${SERVER_LOG_PATH[$1]}"
 
-	local regex="${LOG_REGEX} ($3)"
+	local regex="${SERVER_CONSOLE_EVENT_OUTPUT_REGEX[$1]} ($3)"
 	local timeout_deadline=$(( $(now) + $4 ))
 
 	# Read log, break if nothing is read in $4 seconds
@@ -841,11 +839,12 @@ server_log_get_line() {
 server_log_dots_for_lines() {
 	server_property "$1" USERNAME
 	server_property "$1" LOG_PATH
+	server_property "$1" CONSOLE_EVENT_REGEX
 
 	# Make sure there is a server log to check
 	as_user "${SERVER_USERNAME[$1]}" "touch ${SERVER_LOG_PATH[$1]}"
 
-	local regex="${LOG_REGEX} ($3)"
+	local regex="${SERVER_CONSOLE_EVENT_OUTPUT_REGEX[$1]} ($3)"
 	local timeout_deadline=$(( $(now) + $4 ))
 
 	# Read log, break if nothing is read in $4 seconds

--- a/init/msm
+++ b/init/msm
@@ -292,7 +292,7 @@ now() {
 # $1: A server log line
 # returns: Time in seconds since 1970-01-01 00:00:00 UTC
 log_line_get_time() {
-	time_string="$(echo "$1" | awk '{print $1 " " $2}')"
+	time_string="$(echo "$1" | awk 'BEGIN{FS="[ \][/:]+"}; {print  $1 " " $2 ":" $3 ":" $4}')"
 	date -d "$time_string" "+%s" 2> /dev/null
 }
 

--- a/init/msm
+++ b/init/msm
@@ -826,7 +826,7 @@ server_log_get_line() {
 			RETURN="${BASH_REMATCH[1]}"
 			return 0
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
 }
 
 # The same as server_log_get_line, but prints a dot instead of the log line
@@ -865,7 +865,7 @@ server_log_dots_for_lines() {
 				return 0
 			fi
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\"")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
 }
 
 # Sends as string to a server for execution
@@ -3150,7 +3150,7 @@ command_server_cmdlog() {
 		echo "Now watching logs (press Ctrl+C to exit):"
 		echo "..."
 		server_eval "$1" "${*:2}"
-		as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=5 --sleep-interval=0.1 ${SERVER_LOG_PATH[$1]}"
+		as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=5 --sleep-interval=0.1 ${SERVER_LOG_PATH[$1]} 2>/dev/null"
 	else
 		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi

--- a/msm.conf
+++ b/msm.conf
@@ -137,7 +137,7 @@ DEFAULT_COMPLETE_BACKUP_FOLLOW_SYMLINKS="false"
 
 # The location of standard Minecraft server files, relative to the
 # server directory
-DEFAULT_LOG_PATH="server.log"
+DEFAULT_LOG_PATH="logs/latest.log"
 DEFAULT_PROPERTIES_PATH="server.properties"
 DEFAULT_WHITELIST_PATH="white-list.txt"
 DEFAULT_BANNED_PLAYERS_PATH="banned-players.txt"

--- a/versioning/minecraft/1.2.0.sh
+++ b/versioning/minecraft/1.2.0.sh
@@ -1,5 +1,6 @@
 # MSM version file for Minecraft 1.2.0 and above
 
+console_event REGEX "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.*\]"
 console_event START:30 "Done"
 
 console_command WHITELIST_ON "whitelist on"

--- a/versioning/minecraft/1.7.0.sh
+++ b/versioning/minecraft/1.7.0.sh
@@ -1,0 +1,5 @@
+# MSM version file for Minecraft 1.7.0 and above
+
+extends "minecraft/1.3.0"
+
+console_event REGEX "^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\] \[.*\]:"

--- a/versioning/versions.txt
+++ b/versioning/versions.txt
@@ -5,6 +5,7 @@
 # Vanilla Minecraft versions
 minecraft/1.2.0
 minecraft/1.3.0
+minecraft/1.7.0
 
 # CraftBukkit versions
 craftbukkit/1.2.0


### PR DESCRIPTION
Based on the info I found at https://www.hosthorde.com/forums/resources/understanding-minecraft-server-log-files.75/ I believe this should support the log format of at least all release Minecraft versions.

Tested with Minecraft versions 1.2.5, 1.3.2, 1.6.4, 1.7.10, 1.8.8