### PR TITLE
Versionable Properties

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1747,7 +1747,7 @@ server_set_property() {
 # $1: The ID of the server
 # $2: The name of the server property
 server_property() {
-	local VERSIONABLE_PROPERTIES="LOG_PATH;WHITELIST_PATH;BANNED_PLAYERS_PATH;BANNED_IPS_PATH;OPS_PATH OPS_LIST;"
+	local versionable_properties="LOG_PATH;WHITELIST_PATH;BANNED_PLAYERS_PATH;BANNED_IPS_PATH;OPS_PATH OPS_LIST;"
 
 	# Do nothing if we want to load a property handled
 	# by a versioning file that is already loaded.
@@ -1812,7 +1812,7 @@ server_property() {
 		esac
 
 		# If its a command lookup or server path, load from versioning files
-		if [[ "$2" =~ ^CONSOLE_ ]] || [[ "$VERSIONABLE_PROPERTIES" == *"$2;"* ]]; then
+		if [[ "$2" =~ ^CONSOLE_ ]] || [[ "$versionable_properties" == *"$2;"* ]]; then
 			server_property "$1" VERSION_CONF
 
 			if [[ -f "${SERVER_VERSION_CONF[$1]}" ]]; then

--- a/init/msm
+++ b/init/msm
@@ -1718,8 +1718,8 @@ server_set_property() {
 	### Changes to values before setting
 	case "$2" in
 		*_PATH)
-			server_property "$1" PATH
-			if [[ ! "$3" =~ ^${SERVER_PATH[$1]} ]]; then
+			if [[ ! "$3" =~ ^/.+ ]]; then
+				server_property "$1" PATH
 				eval SERVER_$2[$1]=\"${SERVER_PATH[$1]}/$3\"
 			fi
 			;;

--- a/init/msm
+++ b/init/msm
@@ -3157,7 +3157,7 @@ command_server_cmdlog() {
 command_server_console() {
 	if server_is_running "$1"; then
 		server_property "$1" USERNAME
-		as_user "${SERVER_USERNAME[$1]}" "screen -r ${SERVER_SCREEN_NAME[$1]}"
+		as_user "${SERVER_USERNAME[$1]}" "script -q -c 'screen -r ${SERVER_SCREEN_NAME[$1]}' /dev/null"
 	else
 		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi

--- a/init/msm
+++ b/init/msm
@@ -1747,7 +1747,7 @@ server_set_property() {
 # $1: The ID of the server
 # $2: The name of the server property
 server_property() {
-	local versionable_properties="LOG_PATH;WHITELIST_PATH;BANNED_PLAYERS_PATH;BANNED_IPS_PATH;OPS_PATH OPS_LIST;"
+	local versionable_properties="LOG_PATH;WHITELIST_PATH;BANNED_PLAYERS_PATH;BANNED_IPS_PATH;OPS_PATH;OPS_LIST;"
 
 	# Do nothing if we want to load a property handled
 	# by a versioning file that is already loaded.

--- a/init/msm
+++ b/init/msm
@@ -1747,6 +1747,8 @@ server_set_property() {
 # $1: The ID of the server
 # $2: The name of the server property
 server_property() {
+	local VERSIONABLE_PROPERTIES="LOG_PATH;WHITELIST_PATH;BANNED_PLAYERS_PATH;BANNED_IPS_PATH;OPS_PATH OPS_LIST;"
+
 	# Do nothing if we want to load a property handled
 	# by a versioning file that is already loaded.
 	if [[ "$2" =~ ^CONSOLE_ ]] && [ "${SERVER_VERSIONING_LOADED[$1]}" == "true" ]; then
@@ -1810,7 +1812,7 @@ server_property() {
 		esac
 
 		# If its a command lookup or server path, load from versioning files
-		if [[ "$2" =~ ^CONSOLE_ ]] || [[ "$2" =~ _PATH$ ]]; then
+		if [[ "$2" =~ ^CONSOLE_ ]] || [[ "$VERSIONABLE_PROPERTIES" == *"$2;"* ]]; then
 			server_property "$1" VERSION_CONF
 
 			if [[ -f "${SERVER_VERSION_CONF[$1]}" ]]; then

--- a/init/msm
+++ b/init/msm
@@ -1782,7 +1782,9 @@ server_property() {
 					if [[ -z "${VERSIONS_NEWEST_MINECRAFT_PATH}" ]]; then
 						msm_warning "No version set for server, and no default found. Please use 'msm update' to download defaults"
 					else
-						msm_info "Assuming 'minecraft/${VERSIONS_NEWEST_MINECRAFT_VERSION}' for this server. You should override this value by adding 'msm-version=minecraft/x.x.x' to '${SERVER_CONF[$1]}' to make this message go away"
+						if [[ ! "$arg" =~ logroll|config ]]; then
+							msm_info "Assuming 'minecraft/${VERSIONS_NEWEST_MINECRAFT_VERSION}' for this server. You should override this value by adding 'msm-version=minecraft/x.x.x' to '${SERVER_CONF[$1]}' to make this message go away"
+						fi
 						SERVER_VERSION_CONF[$1]="${VERSIONS_NEWEST_MINECRAFT_PATH}"
 					fi
 				else

--- a/init/msm
+++ b/init/msm
@@ -1715,6 +1715,32 @@ server_connected() {
 # $3: The value for the property
 server_set_property() {
 	eval SERVER_$2[$1]=\"$3\"
+	### Changes to values before setting
+	case "$2" in
+		*_PATH)
+			server_property "$1" PATH
+			if [[ ! "$3" =~ ^${SERVER_PATH[$1]} ]]; then
+				eval SERVER_$2[$1]=\"${SERVER_PATH[$1]}/$3\"
+			fi
+			;;
+		SCREEN_NAME)
+			eval SERVER_$2[$1]=\"${SERVER_SCREEN_NAME[$1]//\{SERVER_NAME\}/${SERVER_NAME[$1]}}\"
+			;;
+		MESSAGE_STOP)
+			server_property "$1" STOP_DELAY
+			eval SERVER_$2[$1]=\"${SERVER_MESSAGE_STOP[$1]//\{DELAY\}/${SERVER_STOP_DELAY[$1]}}\"
+			;;
+		MESSAGE_RESTART)
+			server_property "$1" RESTART_DELAY
+			eval SERVER_$2[$1]=\"${SERVER_MESSAGE_RESTART[$1]//\{DELAY\}/${SERVER_RESTART_DELAY[$1]}}\"
+			;;
+		INVOCATION)
+			server_property "$1" RAM
+			server_property "$1" JAR_PATH
+			eval SERVER_$2[$1]=\"${SERVER_INVOCATION[$1]//\{RAM\}/${SERVER_RAM[$1]}}\"
+			eval SERVER_$2[$1]=\"${SERVER_INVOCATION[$1]//\{JAR\}/${SERVER_JAR_PATH[$1]}}\"
+			;;
+	esac
 }
 
 # Get the value of a server property
@@ -1783,8 +1809,8 @@ server_property() {
 				;;
 		esac
 
-		# If its a command lookup, load from versioning files
-		if [[ "$2" =~ ^CONSOLE_ ]]; then
+		# If its a command lookup or server path, load from versioning files
+		if [[ "$2" =~ ^CONSOLE_ ]] || [[ "$2" =~ _PATH$ ]]; then
 			server_property "$1" VERSION_CONF
 
 			if [[ -f "${SERVER_VERSION_CONF[$1]}" ]]; then
@@ -1794,61 +1820,44 @@ server_property() {
 				SERVER_VERSIONING_LOADED[$1]="true"
 			fi
 
-			return 0
+			if [[ "$2" =~ ^CONSOLE_ ]]; then
+				return 0
+			fi
 		fi
 
 		# If not a non-overridable load from conf
-		to_properties_name "$2"
-		local name="$RETURN"
+		read_server_conf "$1" "$2"
 
-		if [[ "$name" =~ ^properties\-(.*)$ ]]; then
-			name="${BASH_REMATCH[1]}"
-		else
-			name="msm-$name"
-		fi
-
-		server_property "$1" CONF
-
-		local from_conf="$(sed -rn "s/^$name=('|\"|)(.*)\1/\2/ip" "${SERVER_CONF[$1]}" | tail -n 1)"
-
-		if [ ! -z "$from_conf" ]; then
-			# If the value is found in the server conf file (server.properties)
-			# then set that as value for the property
-			eval SERVER_$2[$1]=\"$from_conf\"
-		else
-			# Otherwise use the default value
+		local target_varname=SERVER_$2[$1]
+		if [ -z ${!target_varname} ]; then
+			# if its still empty use the default value
 			manager_property "DEFAULT_$2"
-			eval SERVER_$2[$1]=\"\$SETTINGS_DEFAULT_$2\"
+			server_set_property "$1" "$2" "\$SETTINGS_DEFAULT_$2"
 		fi
+	fi
+}
 
-		### Post-changes to variables after loading
+#Checks server config for overriding value
+# $1: The ID of the server
+# $2: The name of the server property
+read_server_conf(){
+	server_property "$1" CONF
 
-		# If it is a path make that path absolute
-		if [[ "$2" =~ _PATH$ ]]; then
-			server_property "$1" PATH
-			eval SERVER_$2[$1]=\"${SERVER_PATH[$1]}/\${SERVER_$2[$1]}\"
-		fi
+	to_properties_name "$2"
+	local name="$RETURN"
 
-		# Replace any place holders in a property we just loaded
-		case "$2" in
-			SCREEN_NAME)
-				server_set_property "$1" "$2" "${SERVER_SCREEN_NAME[$1]//\{SERVER_NAME\}/${SERVER_NAME[$1]}}"
-				;;
-			MESSAGE_STOP)
-				server_property "$1" STOP_DELAY
-				server_set_property "$1" "$2" "${SERVER_MESSAGE_STOP[$1]//\{DELAY\}/${SERVER_STOP_DELAY[$1]}}"
-				;;
-			MESSAGE_RESTART)
-				server_property "$1" RESTART_DELAY
-				server_set_property "$1" "$2" "${SERVER_MESSAGE_RESTART[$1]//\{DELAY\}/${SERVER_RESTART_DELAY[$1]}}"
-				;;
-			INVOCATION)
-				server_property "$1" RAM
-				server_property "$1" JAR_PATH
-				server_set_property "$1" "$2" "${SERVER_INVOCATION[$1]//\{RAM\}/${SERVER_RAM[$1]}}"
-				server_set_property "$1" "$2" "${SERVER_INVOCATION[$1]//\{JAR\}/${SERVER_JAR_PATH[$1]}}"
-				;;
-		esac
+	if [[ "$name" =~ ^properties\-(.*)$ ]]; then
+		name="${BASH_REMATCH[1]}"
+	else
+		name="msm-$name"
+	fi
+
+	local from_conf="$(sed -rn "s/^$name=('|\"|)(.*)\1/\2/ip" "${SERVER_CONF[$1]}" | tail -n 1)"
+
+	if [ ! -z "$from_conf" ]; then
+		# If the value is found in the server conf file (server.properties)
+		# then set that as value for the property
+		server_set_property "$1" "$2" "$from_conf"
 	fi
 }
 
@@ -4043,6 +4052,14 @@ console_command() {
 	eval SERVER_CONSOLE_COMMAND_TIMEOUT_${command_name}[$VERSIONING_SERVER_ID]=\"$command_timeout\"
 }
 
+# Defines a servers property variables, VERSIONING_SERVER_ID
+# must be set before calling this function
+# $1: The name of the property
+# $2: The value of the property
+set_property() {
+	server_set_property "$VERSIONING_SERVER_ID" "$1" "$2"
+	read_server_conf "$VERSIONING_SERVER_ID" "$1"
+}
 
 
 

--- a/versioning/minecraft/1.2.0.sh
+++ b/versioning/minecraft/1.2.0.sh
@@ -1,5 +1,7 @@
 # MSM version file for Minecraft 1.2.0 and above
 
+set_property LOG_PATH "server.log"
+
 console_event REGEX "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[.*\]"
 console_event START:30 "Done"
 

--- a/versioning/minecraft/1.7.0.sh
+++ b/versioning/minecraft/1.7.0.sh
@@ -2,4 +2,6 @@
 
 extends "minecraft/1.3.0"
 
+set_property LOG_PATH "logs/latest.log"
+
 console_event REGEX "^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\] \[.*\]:"


### PR DESCRIPTION
This will allow some server properties to be stored in the version files. This is for feature request #309, more detail on implementation can be found in the issue discussion.

To test the new code I did the following on a Debian Jessie install, and a CentOS 7 install.

Started, stopped, and opened the console of, server instances running versions; 1.2.5, 1.6.4, 1.7.10, and 1.8.8.

Ran the commands below to confirmed that all variables/setting get dealt with and set correctly. When performing this test the only value that differed between the two branches was `LOG_PATH`, as expected.

```bash
#Ensure the UPDATE_URL is set to the master branch
msm update
msm config > master.txt
msm 1-2-5 config >> master.txt
msm 1-7-10 config >> master.txt
msm 1-8-8 config >> master.txt

#Ensure the UPDATE_URL is set to the versionable_properties branch
msm update
msm config > versionable_properties.txt
msm 1-2-5 config >> versionable_properties.txt
msm 1-7-10 config >> versionable_properties.txt
msm 1-8-8 config >> versionable_properties.txt

diff -u master.txt versionable_properties.txt
```
I also snuck in commit 66c60976b5634a9df53eaf67de501de76a00fa4f to addresses issue #208. `msm [SERVER] console` now works when run as root as well as the owner of the server process (defaults to minecraft). 