### PR TITLE
[269] Initial fix for msm not shutting down when server is shutdown/reboot

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -2080,6 +2080,8 @@ manager_dirty_all() {
 
 # Starts all servers
 command_start() {
+	# Required lock file for init.d to properly shutdown
+	touch /var/lock/subsys/msm
 	# Required start option, for debian init.d scripts
 	for ((server=0; server<${NUM_SERVERS}; server++)); do
 
@@ -2105,11 +2107,15 @@ command_start() {
 
 # Stops all servers after a delay
 command_stop() {
+	# Required lock file for init.d to properly shutdown
+	rm -f /var/lock/subsys/msm
 	manager_stop_all_servers "stop"
 }
 
 # Stops all servers without delay
 command_stop_now() {
+	# Required lock file for init.d to properly shutdown
+	rm -f /var/lock/subsys/msm
 	manager_stop_all_servers_now
 }
 


### PR DESCRIPTION
This fix is for issue 269. After fighting this one for 4 hours last night, I finally learned that init.d relies on lockfiles for initiating shutdown of a service. Google returns many results like this:

http://www.nico.schottelius.org/blog/why-centos-does-not-stop-your-init-script/

So I went ahead and added lock creation and removal of /var/lock/subsys/msm in the obvious places in /etc/init.d/msm

Now on reboot and shutdown, msm properly is stopped, and RAM is copied to disk. 

I tested this on Amazon Linux (centos based), works for both reboot and shutdown. Also works when stopping the AWS instance from the AWS dashboard. 


