### PR TITLE
Fixes error when invoking "msm start".

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1833,7 +1833,7 @@ server_property() {
 		read_server_conf "$1" "$2"
 
 		local target_varname=SERVER_$2[$1]
-		if [ -z ${!target_varname} ]; then
+		if [ -z "${!target_varname}" ]; then
 			# if its still empty use the default value
 			manager_property "DEFAULT_$2"
 			server_set_property "$1" "$2" "\$SETTINGS_DEFAULT_$2"


### PR DESCRIPTION
I was running "msm start" to start one active server (out of two) but would get
the error from the output below:

   [INACTIVE] Server "server1" leaving stopped, as this server is inactive.
   [ACTIVE] Server "server2" starting:
   /usr/local/bin/msm: line 1836: [: too many arguments
   My Adventure World
   Maintaining world symbolic links... Done.
   Synchronising flagged worlds on disk to RAM... Done.
   Starting server.............. Done.

Wrapping the variable reference at that line with double quotes fixed the issue.
