### PR TITLE
Fixes hundreds of hanging ps lines caused by backup execution

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -824,7 +824,7 @@ server_log_get_line() {
 			RETURN="${BASH_REMATCH[1]}"
 			return 0
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ -F --lines=20 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
 }
 
 # The same as server_log_get_line, but prints a dot instead of the log line
@@ -860,7 +860,7 @@ server_log_dots_for_lines() {
 				return 0
 			fi
 		fi
-	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ --follow=name --retry --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
+	done < <(as_user "${SERVER_USERNAME[$1]}" "tail --pid=$$ -F --lines=100 --sleep-interval=0.1 \"${SERVER_LOG_PATH[$1]}\" 2>/dev/null")
 }
 
 # Sends as string to a server for execution


### PR DESCRIPTION
32643 ?        S      0:00      0   882 113381 1476  0.0 /bin/bash /etc/init.d/msm all worlds todisk
32646 ?        S      0:00      0   882 112233  256  0.0 bash -c tail --pid=31635 --follow=name --retry --lines=20 --sleep-interval=0.1 "/opt/msm/servers/build/server.log" 2>/dev/null
3