### PR TITLE
Fix download vanilla server

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1110,13 +1110,13 @@ jargroup_getlatest() {
                     local versions_url="https://launchermeta.mojang.com/mc/game/version_manifest.json"
                     local versions_file="/tmp/minecraft_versions.json"
                     as_user "$SETTINGS_USERNAME" "wget --quiet $wget_opts --no-check-certificate -O '$versions_file' '$versions_url'"
-                    local latest_package_url=$(as_user "$SETTINGS_USERNAME" "egrep -o "\""(\{[^}]*\\"\"type\\"\"\:\\"\"${versions_target}\\"\"[^}]*\})"\"" $versions_file | egrep -o -m1 'https\\:\\/\\/launchermeta\\.mojang\\.com[^\"]*'")
+                    local latest_package_url=$(as_user "$SETTINGS_USERNAME" "cat $versions_file | jq -r '.versions | sort_by(.releaseTime) | map(select(.type | contains ("\""release"\""))) | last | .url'")
                     local latest_version=$(as_user "$SETTINGS_USERNAME" "echo ${latest_package_url##*/} | sed s/.json//")
 
-                    if [[ -n "$latest_package_url" ]]; then
-			local package_file="/tmp/minecraft_package.json"
-			as_user "$SETTINGS_USERNAME" "wget --quiet $wget_opts --no-check-certificate -O '$package_file' '$latest_package_url'"
-			local jar_url=$(as_user "$SETTINGS_USERNAME" "egrep -o -m1 'https.*server\\.jar' $package_file")
+		            if [[ -n "$latest_package_url" ]]; then
+			            local package_file="/tmp/minecraft_package.json"
+			            as_user "$SETTINGS_USERNAME" "wget --quiet $wget_opts --no-check-certificate -O '$package_file' '$latest_package_url'"
+                        local jar_url=$(as_user "$SETTINGS_USERNAME" "cat $package_file | jq -r '.downloads.server.url'")
                     fi
                 fi
 

--- a/init/msm
+++ b/init/msm
@@ -1090,12 +1090,12 @@ jargroup_getlatest() {
 					error_exit FILE_NOT_FOUND "$error"
 				fi
 
-                                # test wget for --trust-server-names option
-                                local wget_opts="--trust-server-names"
-                                wget $wget_opts >/dev/null 2>&1
-                                if [[ $? != 1 ]]; then
-                                    wget_opts=""
-                                fi
+                # test wget for --trust-server-names option
+                local wget_opts="--trust-server-names"
+                wget $wget_opts >/dev/null 2>&1
+                if [[ $? != 1 ]]; then
+                    wget_opts=""
+                fi
 
                 # If target contains the word 'minecraft' or 'minecraft-snapshot', check JSON version file for correct filename
                 # This method allows for backwards compatibility with previous releases
@@ -1423,7 +1423,7 @@ server_start() {
 
 		if [[ -f "${SERVER_PATH[$1]}"/eula.txt ]]; then
 			if ! grep -q -i 'eula=true' "${SERVER_PATH[$1]}"/eula.txt; then
-				echo " Could not start the server as you first need to agree to an EULA. See eula.txt for more info."
+				echo " Could not start the server as you first need to agree to an EULA. See eula.txt for more info (${SERVER_PATH[$1]}/eula.txt)."
 				return
 			fi
 		fi

--- a/installers/arch.sh
+++ b/installers/arch.sh
@@ -9,7 +9,7 @@ function update_system_packages() {
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo pacman --noconfirm -S screen rsync zip wget || install_error "Couldn't install dependencies"
+    sudo pacman --noconfirm -S screen rsync zip wget jq || install_error "Couldn't install dependencies"
 }
 
 function enable_init() {

--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
 wget -q ${UPDATE_URL}/installers/common.sh -O /tmp/msmcommon.sh
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
@@ -10,7 +12,7 @@ function update_system_packages() {
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo apt-get install screen rsync zip || install_error "Couldn't install dependencies"
+    sudo apt-get install screen rsync zip jq || install_error "Couldn't install dependencies"
 }
 
 function enable_init() {

--- a/installers/redhat.sh
+++ b/installers/redhat.sh
@@ -9,7 +9,7 @@ function update_system_packages() {
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo yum install screen rsync zip java || install_error "Couldn't install dependencies"
+    sudo yum install screen rsync zip java jq || install_error "Couldn't install dependencies"
 }
 
 function enable_init() {


### PR DESCRIPTION
Hi everybody!

This is a fix for #364, which will allow basic setup with v1.13.1 again.
The main change is the switch from regular expressions, for fetching the latest release version of minecraft out of the json package files, to the json parser 'jq'.
I let jq filter out the "release" entries, sort by releaseTime and fetch the latest version of it.

Since the whole minecraft server relies more and more on json files this move makes sense to me to avoid errors after minor changes to the json structure.

Cheers