### PR TITLE
Enable universe repository on Ubuntu for jq package

### DIFF
--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -6,6 +6,12 @@ source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 
 function update_system_packages() {
     install_log "Updating sources"
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        if [ $NAME == 'Ubuntu' ]; then
+            sudo add-apt-repository universe || install_error "Couldn't enable universe repository"
+        fi
+    fi
     sudo apt-get update || install_error "Couldn't update package list"
     sudo apt-get upgrade || install_error "Couldn't upgrade packages"
 }


### PR DESCRIPTION
Ubuntu server does not have the universe repository enabled by default, which is required for the jq This adds logic to enable that repository on Ubuntu.

Resolves #366 