### PR TITLE
handle cases where /etc/os-releasse NAME var contains spaces

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -3284,7 +3284,7 @@ register_settings() {
 	register_setting RDIFF_BACKUP_ROTATION "7"
 
 
-	register_setting UPDATE_URL "https://raw.githubusercontent.com/msmhq/msm/latest"
+	register_setting UPDATE_URL "https://raw.githubusercontent.com/hdon/msm/master"
 
 	register_setting WORLD_ARCHIVE_PATH "/opt/msm/archives/worlds"
 	register_setting LOG_ARCHIVE_PATH "/opt/msm/archives/logs"

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -33,7 +33,7 @@ function config_installation() {
 
     echo -n "Add new user as system account? [y/N]: "
     read answer
-    if [[ $answer != "y" ]]; then
+    if [ $answer = "y" ]; then
         msm_user_system=true
     fi
 

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -2,6 +2,19 @@ msm_dir="/opt/msm"
 msm_user="minecraft"
 msm_user_system=false
 dl_dir="$(mktemp -d -t msm-XXX)"
+sudo=sudo
+
+# Are we root?
+if [ "$(whoami)" = root ] ; then
+  sudo=
+else
+  # Test for presence of sudo
+  if ! which sudo > /dev/null ; then
+    echo 'warning: I probably need root privileges but could not find sudo.'
+    echo 'warning: I will try to make do without.'
+    sudo=
+  fi
+fi
 
 # Outputs an MSM INSTALL log line
 function install_log() {
@@ -61,9 +74,9 @@ function install_dependencies() {
 function add_minecraft_user() {
     install_log "Creating default user '${msm_user}'"
     if $msm_user_system; then
-        sudo useradd ${msm_user} --home "$msm_dir"
+        $sudo useradd ${msm_user} --home "$msm_dir"
     else
-        sudo useradd ${msm_user} --system --home "$msm_dir"
+        $sudo useradd ${msm_user} --system --home "$msm_dir"
     fi
 }
 
@@ -71,9 +84,9 @@ function add_minecraft_user() {
 function create_msm_directories() {
     install_log "Creating MSM directories"
     if [ ! -d "$msm_dir" ]; then
-        sudo mkdir -p "$msm_dir" || install_error "Couldn't create directory '$msm_dir'"
+        $sudo mkdir -p "$msm_dir" || install_error "Couldn't create directory '$msm_dir'"
     fi
-    sudo chown -R $msm_user:$msm_user "$msm_dir" || install_error "Couldn't change file ownership for '$msm_dir'"
+    $sudo chown -R $msm_user:$msm_user "$msm_dir" || install_error "Couldn't change file ownership for '$msm_dir'"
 }
 
 # Fetches latest msm.conf, cron job, and init script
@@ -83,15 +96,15 @@ function download_latest_files() {
     fi
 
     install_log "Downloading latest MSM configuration file"
-    sudo wget ${UPDATE_URL}/msm.conf \
+    $sudo wget ${UPDATE_URL}/msm.conf \
         -O "$dl_dir/msm.conf.orig" || install_error "Couldn't download configuration file"
 
     install_log "Downloading latest MSM cron file"
-    sudo wget ${UPDATE_URL}/cron/msm \
+    $sudo wget ${UPDATE_URL}/cron/msm \
         -O "$dl_dir/msm.cron.orig" || install_error "Couldn't download cron file"
 
     install_log "Downloading latest MSM version"
-    sudo wget ${UPDATE_URL}/init/msm \
+    $sudo wget ${UPDATE_URL}/init/msm \
         -O "$dl_dir/msm.init.orig" || install_error "Couldn't download init file"
 }
 
@@ -99,24 +112,24 @@ function download_latest_files() {
 function patch_latest_files() {
     # patch config file
     install_log "Patching MSM configuration file"
-    sudo sed 's#USERNAME="minecraft"#USERNAME="'$msm_user'"#g' "$dl_dir/msm.conf.orig" | \
+    $sudo sed 's#USERNAME="minecraft"#USERNAME="'$msm_user'"#g' "$dl_dir/msm.conf.orig" | \
         sed "s#/opt/msm#$msm_dir#g" | \
         sed "s#UPDATE_URL=.*\$#UPDATE_URL=\"$UPDATE_URL\"#" >"$dl_dir/msm.conf"
 
     # patch cron file
     install_log "Patching MSM cron file"
-    sudo awk '{ if ($0 !~ /^#/) sub(/minecraft/, "'$msm_user'"); print }' \
+    $sudo awk '{ if ($0 !~ /^#/) sub(/minecraft/, "'$msm_user'"); print }' \
         "$dl_dir/msm.cron.orig" >"$dl_dir/msm.cron"
 
     # patch init file
     install_log "Patching MSM init file"
-    sudo cp "$dl_dir/msm.init.orig" "$dl_dir/msm.init"
+    $sudo cp "$dl_dir/msm.init.orig" "$dl_dir/msm.init"
 }
 
 # Installs msm.conf into /etc
 function install_config() {
     install_log "Installing MSM configuration file"
-    sudo install -b -m0644 "$dl_dir/msm.conf" /etc/msm.conf
+    $sudo install -b -m0644 "$dl_dir/msm.conf" /etc/msm.conf
     if [ ! -e /etc/msm.conf ]; then
         install_error "Couldn't install configuration file"
     fi
@@ -125,17 +138,17 @@ function install_config() {
 # Installs msm.cron into /etc/cron.d
 function install_cron() {
     install_log "Installing MSM cron file"
-    sudo install -m0644 "$dl_dir/msm.cron" /etc/cron.d/msm || install_error "Couldn't install cron file"
-    sudo /etc/init.d/cron reload
+    $sudo install -m0644 "$dl_dir/msm.cron" /etc/cron.d/msm || install_error "Couldn't install cron file"
+    $sudo /etc/init.d/cron reload
 }
 
 # Installs init script into /etc/init.d
 function install_init() {
     install_log "Installing MSM init file"
-    sudo install -b "$dl_dir/msm.init" /etc/init.d/msm || install_error "Couldn't install init file"
+    $sudo install -b "$dl_dir/msm.init" /etc/init.d/msm || install_error "Couldn't install init file"
 
     install_log "Making MSM accessible as the command 'msm'"
-    sudo ln -s /etc/init.d/msm /usr/local/bin/msm
+    $sudo ln -s /etc/init.d/msm /usr/local/bin/msm
 }
 
 # Enables init script in default runlevels
@@ -147,13 +160,13 @@ function enable_init() {
 # Updates rest of MSM using init script updater
 function update_msm() {
     install_log "Asking MSM to update itself"
-    sudo /etc/init.d/msm update --noinput
+    $sudo /etc/init.d/msm update --noinput
 }
 
 # Updates rest of MSM using init script updater
 function setup_jargroup() {
     install_log "Setup default jar groups"
-    sudo /etc/init.d/msm jargroup create minecraft minecraft
+    $sudo /etc/init.d/msm jargroup create minecraft minecraft
 }
 
 function install_complete() {

--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -8,7 +8,7 @@ function update_system_packages() {
     install_log "Updating sources"
     if [ -f /etc/os-release ]; then
         . /etc/os-release
-        if [ $NAME == 'Ubuntu' ]; then
+        if [ "$NAME" == 'Ubuntu' ]; then
             sudo add-apt-repository universe || install_error "Couldn't enable universe repository"
         fi
     fi

--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
+UPDATE_URL="https://raw.githubusercontent.com/hdon/msm/master"
 wget -q ${UPDATE_URL}/installers/common.sh -O /tmp/msmcommon.sh
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 


### PR DESCRIPTION
Here's my `os-release` file:

```
# cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

It leads to this error during installation when following the installation instructions in the README:

```
MSM INSTALL: Updating sources
/tmp/msm: line 11: [: too many arguments
```