### PR TITLE
Made script ZSH-friendly

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1843,7 +1843,7 @@ server_property() {
 		# If not a non-overridable load from conf
 		read_server_conf "$1" "$2"
 
- 		eval local target_varname=\$SERVER_$2[$1]
+ 		eval local target_varname=\"\${SERVER_$2[$1]}\"
                 if [[ -z "$target_varname" ]]; then
 			# if its still empty use the default value
 			manager_property "DEFAULT_$2"

--- a/init/msm
+++ b/init/msm
@@ -1196,7 +1196,7 @@ jargroup_delete() {
 			printf "Are you sure you want to delete this jar group [y/N]: "
 
 			read answer
-			if [[ "$answer" =~ ^y|Y|yes$ ]]; then
+			if [[ "$answer" =~ (^y|Y|yes$) ]]; then
 				as_user "$SETTINGS_USERNAME" "rm -rf \"$SETTINGS_JAR_STORAGE_PATH/$1\""
 				echo "Jar group deleted."
 			else
@@ -1793,7 +1793,7 @@ server_property() {
 					if [[ -z "${VERSIONS_NEWEST_MINECRAFT_PATH}" ]]; then
 						msm_warning "No version set for server, and no default found. Please use 'msm update' to download defaults"
 					else
-						if [[ ! "$arg" =~ logroll|config ]]; then
+						if [[ ! "$arg" =~ (logroll|config) ]]; then
 							msm_info "Assuming 'minecraft/${VERSIONS_NEWEST_MINECRAFT_VERSION}' for this server. You should override this value by adding 'msm-version=minecraft/x.x.x' to '${SERVER_CONF[$1]}' to make this message go away"
 						fi
 						SERVER_VERSION_CONF[$1]="${VERSIONS_NEWEST_MINECRAFT_PATH}"

--- a/init/msm
+++ b/init/msm
@@ -1843,8 +1843,8 @@ server_property() {
 		# If not a non-overridable load from conf
 		read_server_conf "$1" "$2"
 
-		local target_varname=SERVER_$2[$1]
-		if [ -z "${!target_varname}" ]; then
+ 		eval local target_varname=\$SERVER_$2[$1]
+                if [[ -z "$target_varname" ]]; then
 			# if its still empty use the default value
 			manager_property "DEFAULT_$2"
 			server_set_property "$1" "$2" "\$SETTINGS_DEFAULT_$2"


### PR DESCRIPTION
Changed regex and indirect expansion to ZSH- and BASH-compatible syntax, resolving errors when trying to tab-complete in a ZSH user shell.

See Issue #387 