### PR TITLE
Remove invalid java invocation arguments

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -3317,7 +3317,7 @@ register_settings() {
 	register_server_setting WORLDS_FLAG_INRAM "inram"
 
 	register_server_setting RAM "1024"
-	register_server_setting INVOCATION "java -Xms{RAM}M -Xmx{RAM}M -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -jar {JAR} nogui"
+	register_server_setting INVOCATION "java -Xms{RAM}M -Xmx{RAM}M -jar {JAR} nogui"
 	register_server_setting STOP_DELAY "10"
 	register_server_setting RESTART_DELAY "10"
 

--- a/msm.conf
+++ b/msm.conf
@@ -162,7 +162,7 @@ DEFAULT_RAM="1024"
 #
 # Hard coding values here (not using {MEMORY} and {JAR} tags) will prevent
 # servers from individually overriding those values.
-DEFAULT_INVOCATION="java -Xms{RAM}M -Xmx{RAM}M -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -jar {JAR} nogui"
+DEFAULT_INVOCATION="java -Xms{RAM}M -Xmx{RAM}M -jar {JAR} nogui"
 
 
 # The default time to delay between warning players the server is stopping and

--- a/test.sh
+++ b/test.sh
@@ -48,7 +48,7 @@ setUp() {
 	echo "DEBUG=\"true\"" >> "$MSM_CONF"
 	echo "DEFAULT_USERNAME=\"${USERNAME}\"" >> "$MSM_CONF"
 	echo "DEFAULT_SCREEN_NAME=\"msmtest-${SERVER_NAME}\"" >> "$MSM_CONF"
-	echo "DEFAULT_INVOCATION=\"java -Xmx${TEST_RAM}M -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalPacing -XX:+AggressiveOpts -jar {JAR} nogui\"" >> "$MSM_CONF"
+	echo "DEFAULT_INVOCATION=\"java -Xmx${TEST_RAM}M -jar {JAR} nogui\"" >> "$MSM_CONF"
 
 	source $TEST_SCRIPT
 	


### PR DESCRIPTION
The UseConcMarkSweepGC, CMSIncrementalPacing, and AggressiveOpts
arguments are no longer supported in current versions of Java.
Java fails to start with them present.

Additionally, having less specific default invocation options
allows supporting more versions of Java and makes for less
maintenance into the future as options are deprecated.

Invocation options can be added to individual server configs, or
to the global config, if the user wants to change the defaults.

Fixes issue #402