### PR TITLE
Convert server txt files to json

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -2780,14 +2780,7 @@ command_server_whitelist_add() {
 			echo_fallback "$RETURN" "Player $player is now whitelisted."
 		done
 	else
-		server_property "$1" WHITELIST_PATH
-
-		for player in "${@:2}"; do
-			if ! grep "^$player\$" "${SERVER_WHITELIST_PATH[$1]}" >/dev/null; then
-				echo "$player" >> "${SERVER_WHITELIST_PATH[$1]}"
-				echo_fallback "$RETURN" "Player $player is now whitelisted."
-			fi
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2802,12 +2795,7 @@ command_server_whitelist_remove() {
 			echo_fallback "$RETURN" "Player $player is no longer whitelisted."
 		done
 	else
-		server_property "$1" WHITELIST_PATH
-
-		for player in "${@:2}"; do
-			sed -ri "/^$player\$/d" "${SERVER_WHITELIST_PATH[$1]}"
-			echo_fallback "$RETURN" "Player $player is no longer whitelisted."
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2839,14 +2827,7 @@ command_server_blacklist_player_add() {
 			echo_fallback "$RETURN" "Player $player is now blacklisted."
 		done
 	else
-		server_property "$1" BANNED_PLAYERS_PATH
-
-		for player in "${@:2}"; do
-			if ! grep "^$player\$" "${SERVER_BANNED_PLAYERS_PATH[$1]}" >/dev/null; then
-				echo "$player" >> "${SERVER_BANNED_PLAYERS_PATH[$1]}"
-				echo "Player $player is now blacklisted."
-			fi
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2860,12 +2841,7 @@ command_server_blacklist_player_remove() {
 			echo_fallback "$RETURN" "Player $player is no longer blacklisted."
 		done
 	else
-		server_property "$1" BANNED_PLAYERS_PATH
-
-		for player in "${@:2}"; do
-			sed -ri "/^$player\$/d" "${SERVER_BANNED_PLAYERS_PATH[$1]}"
-			echo "Player $player is no longer blacklisted."
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2879,14 +2855,7 @@ command_server_blacklist_ip_add() {
 			echo_fallback "$RETURN" "IP address $address is now blacklisted."
 		done
 	else
-		server_property "$1" BANNED_IPS_PATH
-
-		for address in "${@:2}"; do
-			if ! grep "^$address\$" "${SERVER_BANNED_IPS_PATH[$1]}" >/dev/null; then
-				echo "$address" >> "${SERVER_BANNED_IPS_PATH[$1]}"
-				echo "IP address $address is now blacklisted."
-			fi
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2900,12 +2869,7 @@ command_server_blacklist_ip_remove() {
 			echo_fallback "$RETURN" "IP address $address is no longer blacklisted."
 		done
 	else
-		server_property "$1" BANNED_PLAYERS_PATH
-
-		for address in "${@:2}"; do
-			sed -ri "/^$address\$/d" "${SERVER_BANNED_PLAYERS_PATH[$1]}"
-			echo "IP address $address is no longer blacklisted."
-		done
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2955,24 +2919,7 @@ command_server_operator_add() {
 			echo_fallback "$RETURN" "Player $player is now an operator."
 		done
 	else
-		server_property "$1" OPS_PATH
-
-		for player in "${@:2}"; do
-			if ! grep "^$player\$" "${SERVER_OPS_PATH[$1]}" >/dev/null; then
-				echo "$player" >> "${SERVER_OPS_PATH[$1]}"
-			fi
-		done
-	fi
-
-	if [[ $# -gt 2 ]]; then
-		echo -n "The following players are now operators: "
-		echo -n "$2"
-		for player in "${@:3}"; do
-		 	echo -n ", $player"
-		done
-		echo "."
-	else
-		echo "\"$2\" is now an operator."
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 
@@ -2987,24 +2934,7 @@ command_server_operator_remove() {
 			echo_fallback "$RETURN" "Player $player is no longer an operator."
 		done
 	else
-		server_property "$1" OPS_PATH
-
-		for player in "${@:2}"; do
-			for player in "${@:2}"; do
-				sed -ri "/^$player\$/d" "${SERVER_OPS_PATH[$1]}"
-			done
-		done
-	fi
-
-	if [[ $# -gt 2 ]]; then
-		echo -n "The following players are no longer operators: "
-		echo -n "$2"
-		for player in "${@:3}"; do
-		 	echo -n ", $player"
-		done
-		echo "."
-	else
-		echo "\"$2\" is no longer an operator."
+		error_exit SERVER_STOPPED "Server \"${SERVER_NAME[$1]}\" is not running."
 	fi
 }
 

--- a/init/msm
+++ b/init/msm
@@ -1301,15 +1301,19 @@ server_create() {
 		else
 			printf "Creating server directory... "
 			as_user "$SETTINGS_USERNAME" "mkdir -p '$SETTINGS_SERVER_STORAGE_PATH/$1'"
-			as_user "$SETTINGS_USERNAME" "touch '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_WHITELIST_PATH'"
-			as_user "$SETTINGS_USERNAME" "touch '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_BANNED_IPS_PATH'"
-			as_user "$SETTINGS_USERNAME" "touch '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_BANNED_PLAYERS_PATH'"
-			as_user "$SETTINGS_USERNAME" "touch '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_OPS_PATH'"
+			as_user "$SETTINGS_USERNAME" "echo '[]' > '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_WHITELIST_PATH'"
+			as_user "$SETTINGS_USERNAME" "echo '[]' > '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_BANNED_IPS_PATH'"
+			as_user "$SETTINGS_USERNAME" "echo '[]' > '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_BANNED_PLAYERS_PATH'"
+			as_user "$SETTINGS_USERNAME" "echo '[]' > '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_OPS_PATH'"
 
 			# Set default ops users as appropriate
+			# Adding usernames to ops.txt means on first startup minecraft server will
+			# fetch UUIDs for the users and add them to ops.json in the correct format.
+			# Relying on minecraft server to convert isn't ideal in the long term since
+			# it could deprecate the conversion.
 			if [ ! -z "$SETTINGS_DEFAULT_OPS_LIST" ]; then
 				IFS=","; for default_ops_user in $SETTINGS_DEFAULT_OPS_LIST; do
-					as_user "$SETTINGS_USERNAME" "echo $default_ops_user | tr -d ' ' >> '$SETTINGS_SERVER_STORAGE_PATH/$1/$SETTINGS_DEFAULT_OPS_PATH'"
+					as_user "$SETTINGS_USERNAME" "echo $default_ops_user | tr -d ' ' >> '$SETTINGS_SERVER_STORAGE_PATH/$1/ops.txt'"
 				done
 			fi
 
@@ -3304,10 +3308,10 @@ register_settings() {
 	register_server_setting WORLD_STORAGE_PATH "worldstorage"
 	register_server_setting WORLD_STORAGE_INACTIVE_PATH "worldstorage_inactive"
 	register_server_setting LOG_PATH "server.log"
-	register_server_setting WHITELIST_PATH "white-list.txt"
-	register_server_setting BANNED_PLAYERS_PATH "banned-players.txt"
-	register_server_setting BANNED_IPS_PATH "banned-ips.txt"
-	register_server_setting OPS_PATH "ops.txt"
+	register_server_setting WHITELIST_PATH "whitelist.json"
+	register_server_setting BANNED_PLAYERS_PATH "banned-players.json"
+	register_server_setting BANNED_IPS_PATH "banned-ips.json"
+	register_server_setting OPS_PATH "ops.json"
 	register_server_setting OPS_LIST ""
 	register_server_setting JAR_PATH "server.jar"
 

--- a/msm.conf
+++ b/msm.conf
@@ -139,10 +139,10 @@ DEFAULT_COMPLETE_BACKUP_FOLLOW_SYMLINKS="false"
 # server directory
 DEFAULT_LOG_PATH="logs/latest.log"
 DEFAULT_PROPERTIES_PATH="server.properties"
-DEFAULT_WHITELIST_PATH="white-list.txt"
-DEFAULT_BANNED_PLAYERS_PATH="banned-players.txt"
-DEFAULT_BANNED_IPS_PATH="banned-ips.txt"
-DEFAULT_OPS_PATH="ops.txt"
+DEFAULT_WHITELIST_PATH="whitelist.json"
+DEFAULT_BANNED_PLAYERS_PATH="banned-players.json"
+DEFAULT_BANNED_IPS_PATH="banned-ips.json"
+DEFAULT_OPS_PATH="ops.json"
 
 # List of comma-separated users that are added by default to ops.txt on server
 # creation.


### PR DESCRIPTION
This pull request changes the default server files from txt to json.
To support that change, additionally update the wl, bl, and op
commands to no longer edit their corresponding server files but
rely on passthrough commands to the minecraft server.

Operationally, the only difference the user will see is when running 
the commands when the server is not running.  Rather than edit
the txt file, msm will return "Server servername is not running."

Fixes issue #404