### PR TITLE
Fix change log entry for version 0.10.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -6,9 +6,10 @@ Visit https://github.com/msmhq/msm for more information.
 Change Log
 ----------
 
-### [0.9.4](https://github.com/msmhq/msm/compare/0.9.4...0.10.0)
+### [0.10.0](https://github.com/msmhq/msm/compare/0.9.4...0.10.0)
 
-First minor version in 4 years.
+First change log entry in 4 years. There were versions from `0.9.5` to `0.9.10` in the interim period,
+which were not reflected in the change log and some of them haven't been tagged.
 
 * Allow snapshots to be downloaded [#369][#369]
 * Add dollar sign for interpolation [#389][#389]


### PR DESCRIPTION
Previous version of the entry had a typo in the version and
somehow missed the fact that there were a few other releases
in the last few years.

There's not much value in retroactively adding them to the change
log, but we should be more careful in the future.

Addresses https://github.com/msmhq/msm/commit/6c1d8c7c651de35145b865448853f01e30ce3dc6#r45004397.