### PR TITLE
Replace Tender Support link with GitHub Issues

### DIFF
--- a/404.html
+++ b/404.html
@@ -26,7 +26,7 @@
               <li><a href="https://msmhq.com/">Overview</a></li>
               <li><a href="https://msmhq.com/blog/">Blog</a></li>
               <li><a href="https://msmhq.com/docs/">Docs</a></li>
-              <li><a href="https://msm.tenderapp.com/">Support</a></li>
+              <li><a href="https://github.com/msmhq/msm/issues">Support</a></li>
             </ul>
           </div>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
             <li{% if page.tab == "overview" %} class="active"{% endif %}><a href="{{ site.baseurl }}/">Overview</a></li>
             <li{% if page.tab == "blog" %} class="active"{% endif %}><a href="{{ site.baseurl }}/blog/">Blog</a></li>
             <li{% if page.tab == "docs" %} class="active"{% endif %}><a href="{{ site.baseurl }}/docs/">Docs</a></li>
-            <li><a href="https://msm.tenderapp.com/">Support</a></li>
+            <li><a href="https://github.com/msmhq/msm/issues">Support</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Tender Support isn't monitored. GitHub Issues provide at least
some visibility.

Addresses #414.