### PR TITLE
Updated wget_opts

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -1091,7 +1091,8 @@ jargroup_getlatest() {
 				fi
 
                 # test wget for --trust-server-names option
-                local wget_opts="--trust-server-names"
+		# --content-disposition for keeping the remote filename
+                local wget_opts="--trust-server-names --content-disposition"
                 wget $wget_opts >/dev/null 2>&1
                 if [[ $? != 1 ]]; then
                     wget_opts=""


### PR DESCRIPTION
added --content-disposition to $wget_opts for keeping the remote filename when downloading with a Permanent link to latest version
This is usefull if you want to download the latest version of papermc with a perma link like:
https://papermc.io/api/v1/paper/1.16.5/latest/download

Hey. This is my first pull request. I have no clue if what I am doing right now is ok or not. But I would realy like this parameter so I can script and use PaperMC properly.

