### PR TITLE
Fix the git-release GitHub Action workflow constantly creating errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
         PRE_RELEASE: "false"
         CHANGELOG_FILE: "none"
         ALLOW_EMPTY_CHANGELOG: "false"
-        ALLOW_TAG_PREFIX: "true"
       with:
         args: |
             build/*-amd64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: Create Release
 on:
   push:
-    branches:
-      - master
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Release
-      uses: docker://antonyurchenko/git-release:latest
+      uses: docker://antonyurchenko/git-release:v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DRAFT_RELEASE: "false"


### PR DESCRIPTION
This PR fixes the `git-release` GitHub Action so that it does not create a failed workflow error every time any commit is pushed to `master`. Also removes unneeded environment variable which was [deprecated in the v4.0.0 update](https://github.com/anton-yurchenko/git-release/blob/main/CHANGELOG.md#400---2021-06-16) to `git-release`.

The previous syntax was set to trigger `git-release` every time a version tag was created or updated, ***AND*** when any commit was pushed to `master`. I assume the *intended* behavior was to trigger the workflow when a tag *on the `master` branch* is created or updated.

The new syntax will trigger when a tag is updated or created anywhere in the repository, but will still only trigger for tags with names of exactly 3 numbers separated by periods. (i.e. will match `0.9.10` or `1.2.3`, will *not* match `tagname`, `version-0.9.10`, or `0.9`
