### PR TITLE
Fix non-interactive install, and java, software-properties-common, sudo and wget dependencies

### DIFF
--- a/installers/arch.sh
+++ b/installers/arch.sh
@@ -1,15 +1,24 @@
 UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
-curl -L "${UPDATE_URL}/installers/common.sh" -o /tmp/msmcommon.sh  #wget isn't installed on Arch by default
+curl -L "${UPDATE_URL}/installers/common.sh" -o /tmp/msmcommon.sh  # wget isn't installed on Arch by default
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
+
+# Installs sudo if it is not installed
+function install_sudo() {
+    pacman --noconfirm -S sudo
+}
 
 function update_system_packages() {
     install_log "Updating sources"
-    sudo pacman -Syy || install_error "Couldn't update packages"
+    sudo pacman --noconfirm -Syy || install_error "Couldn't update packages"
 }
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo pacman --noconfirm -S screen rsync zip wget jq || install_error "Couldn't install dependencies"
+    sudo pacman --noconfirm -S jq rsync screen wget zip || install_error "Couldn't install dependencies"
+    if ! command -v java > /dev/null 2>&1; then
+        install_log "Installing Java (OpenJDK 17)"
+        sudo pacman --noconfirm -S jre17-openjdk-headless || install_error "Couldn't install Java"
+    fi
 }
 
 function enable_init() {

--- a/installers/common.sh
+++ b/installers/common.sh
@@ -45,6 +45,19 @@ function config_installation() {
     fi
 }
 
+# Verifies if the system has sudo installed and, if not, installs it
+function check_sudo() {
+    if ! command -v sudo > /dev/null 2>&1; then
+        install_sudo
+    fi
+}
+
+# Installs sudo if it is not installed
+function install_sudo() {
+    # OVERLOAD THIS
+    install_error "No function definition for install_sudo"
+}
+
 # Runs a system software update to make sure we're using all fresh packages
 function update_system_packages() {
     # OVERLOAD THIS
@@ -163,9 +176,10 @@ function install_complete() {
 
 function install_msm() {
     config_installation
-    add_minecraft_user
+    check_sudo
     update_system_packages
     install_dependencies
+    add_minecraft_user
     create_msm_directories
     download_latest_files
     patch_latest_files

--- a/installers/debian.sh
+++ b/installers/debian.sh
@@ -4,21 +4,35 @@ UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
 wget -q ${UPDATE_URL}/installers/common.sh -O /tmp/msmcommon.sh
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 
+# Installs sudo if it is not installed
+function install_sudo() {
+    install_log "Installing sudo"
+    DEBIAN_FRONTEND=noninteractive apt-get -yqq install sudo
+}
+
 function update_system_packages() {
     install_log "Updating sources"
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         if [ "$NAME" == 'Ubuntu' ]; then
+            if ! command -v add-apt-repository > /dev/null 2>&1; then
+                sudo apt-get -yqq install software-properties-common
+            fi
+
             sudo add-apt-repository universe || install_error "Couldn't enable universe repository"
         fi
     fi
-    sudo apt-get update || install_error "Couldn't update package list"
-    sudo apt-get upgrade || install_error "Couldn't upgrade packages"
+    sudo apt-get -yqq update || install_error "Couldn't update package list"
+    DEBIAN_FRONTEND=noninteractive sudo apt-get -yqq upgrade || install_error "Couldn't upgrade packages"
 }
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo apt-get install screen rsync zip jq || install_error "Couldn't install dependencies"
+    DEBIAN_FRONTEND=noninteractive sudo apt-get -yqq install jq rsync screen wget zip || install_error "Couldn't install dependencies"
+    if ! command -v java > /dev/null 2>&1; then
+        install_log "Installing Java (OpenJDK 17)"
+        DEBIAN_FRONTEND=noninteractive sudo apt-get -yqq install openjdk-17-jre-headless || install_error "Couldn't install Java"
+    fi
 }
 
 function enable_init() {

--- a/installers/redhat.sh
+++ b/installers/redhat.sh
@@ -2,14 +2,23 @@ UPDATE_URL="https://raw.githubusercontent.com/msmhq/msm/master"
 wget -q ${UPDATE_URL}/installers/common.sh -O /tmp/msmcommon.sh
 source /tmp/msmcommon.sh && rm -f /tmp/msmcommon.sh
 
+# Installs sudo if it is not installed
+function install_sudo() {
+    yum -yq install sudo
+}
+
 function update_system_packages() {
     install_log "Updating sources"
-    sudo yum update --skip-broken || install_error "Couldn't update packages"
+    sudo yum -yq update --skip-broken || install_error "Couldn't update packages"
 }
 
 function install_dependencies() {
     install_log "Installing required packages"
-    sudo yum install screen rsync zip java jq || install_error "Couldn't install dependencies"
+    sudo yum -yq install jq rsync screen wget zip || install_error "Couldn't install dependencies"
+    if ! command -v java > /dev/null 2>&1; then
+        install_log "Installing Java (OpenJDK 17)"
+        sudo yum -yq install java-17-openjdk || install_error "Couldn't install Java"
+    fi
 }
 
 function enable_init() {


### PR DESCRIPTION
* Set dependency installation as non-interactive

Fixes: apt waits for user input when installing dependencies #439

* Add sudo and wget as dependencies

Fixes: Installer assumes system has sudo and wget installed #440

* Add openjdk-17-jre-headless as dependency

The script will install openjdk-17-jre-headless if java isn't installed already. The choice for version 17 was motivated by the fact it is the latest LTS version and also that it is required for running Minecraft 1.18 and above.

Fixes: Make java an MSM installation dependency? #295

* Add software-properties-common as dependency

The Debian script now installs software-properties-common if not installed, so it can use add-apt-repository.

Fixes: Installer assumes software-properties-common is installed on debian system #441

* Fix broken whitespace