### PR TITLE
Github test workflow: bump checkout action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install shunit2
       - name: Check out branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create the minecraft user
         run: sudo adduser --system minecraft
       - name: Run tests


### PR DESCRIPTION
Github action `checkout@v2` uses Node.js v12 which is deprecated, bumped to `checkout@v4`.