### PR TITLE
msm servername config fix failure to update string with a /

### DIFF
--- a/init/msm
+++ b/init/msm
@@ -3139,7 +3139,7 @@ command_server_config() {
 		server_property "$1" CONF
 		if [[ -f "${SERVER_CONF[$1]}" ]]; then
 			if grep "$2" "${SERVER_CONF[$1]}" >/dev/null; then
-				sed -i "s#$2=.*#$2=$3#g" "${SERVER_CONF[$1]}"
+				sed -i "s"$'\x01'"^$2=.*"$'\x01'"$2=$3"$'\x01'"g" "${SERVER_CONF[$1]}"
 			else
 				echo "$2=$3" >> "${SERVER_CONF[$1]}"
 			fi

--- a/init/msm
+++ b/init/msm
@@ -3139,7 +3139,7 @@ command_server_config() {
 		server_property "$1" CONF
 		if [[ -f "${SERVER_CONF[$1]}" ]]; then
 			if grep "$2" "${SERVER_CONF[$1]}" >/dev/null; then
-				sed -i /$2=/s/.*/"$2=$3"/g "${SERVER_CONF[$1]}"
+				sed -i "s#$2=.*#$2=$3#g" "${SERVER_CONF[$1]}"
 			else
 				echo "$2=$3" >> "${SERVER_CONF[$1]}"
 			fi


### PR DESCRIPTION
prevent error when / are present in the value of the config as when changing any config with a path or as in version where a / is expected.

this will fix  issue # 371.
rather than using a # , using an invisible delimiter reduce even more the risk of a user deciding to add a the delimiter in the config value.